### PR TITLE
Add current location to the map

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ const KEYPAIR = { k: 'amenity', v: 'cafe' },
   OVERPASS = 'http://overpass-api.de/api/interpreter',
   MBX = 'pk.eyJ1IjoidG1jdyIsImEiOiIzczJRVGdRIn0.DKkDbTPnNUgHqTDBg7_zRQ',
   MAP = 'tmcw.kbh273ee',
-  PIN = 'pin-l-cafe';
+  PIN = 'pin-l-cafe',
+  LOC = 'pin-s'; 
 
 L.mapbox.accessToken = MBX;
 
@@ -236,8 +237,9 @@ var StaticMap = React.createClass({
   render() {
     return (
       /* jshint ignore:start */
-      <img src={`https://api.tiles.mapbox.com/v4/${MAP}/${PIN}` +
-        `(${this.props.location.longitude},${this.props.location.latitude})` +
+      <img src={`https://api.tiles.mapbox.com/v4/${MAP}/` +
+        `${PIN}(${this.props.location.longitude},${this.props.location.latitude}),` +
+        `${LOC}(${locationStore.location.longitude},${locationStore.location.latitude})` +
         `/${this.props.location.longitude},${this.props.location.latitude}` +
         `,14/300x200@2x.png?access_token=${MBX}`} />
       /* jshint ignore:end */


### PR DESCRIPTION
Show your current location on the static map.

I think this thing is pretty neat. I played around with it today and found that as I tapped around a few different nearby cafes, I kept having to re-orient myself on the map since it re-draws and re-centers on each cafe... so I thought it would be nice to show your current location on the static map. The marker I chose is just a small empty pin. Not sure if you want pull requests or not so no big deal to reject, or replace with anything else.

Here's what it looks like:
![coffeedex_curloc](https://cloud.githubusercontent.com/assets/1214350/5256569/9be054dc-7998-11e4-8e6b-cfb522460c01.png)
